### PR TITLE
Bump Xcode from 26.3 to 26.4

### DIFF
--- a/.github/workflows/ci-examples.yml
+++ b/.github/workflows/ci-examples.yml
@@ -13,11 +13,11 @@ on:
       - LICENSE
 
 env:
-  DEVELOPER_DIR: /Applications/Xcode_26.3.app
+  DEVELOPER_DIR: /Applications/Xcode_26.4.app
 
 jobs:
   build:
-    runs-on: macos-15
+    runs-on: macos-26
     defaults:
       run:
         working-directory: Examples

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,10 +17,10 @@ on:
 jobs:
   run-macos:
     name: ${{ matrix.subcommand }} with Xcode ${{ matrix.xcode }} on macOS
-    runs-on: macos-15
+    runs-on: macos-26
     strategy:
       matrix:
-        xcode: ["26.3"]
+        xcode: ["26.4"]
         subcommand: ["Build"]
     steps:
     - uses: actions/checkout@v4

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 6.2
+// swift-tools-version: 6.3
 
 import PackageDescription
 


### PR DESCRIPTION
## チケット

- なし

## 仕様書・Figma

- なし

## やったこと

- Xcodeを26.3から26.4へ更新
- GitHub ActionsのXcodeバージョン指定を更新
- swift-tools-versionを6.2から6.3へ更新

## やってないこと

- なし

## 参考リンク

- https://github.com/uhooi/Loki/pull/253